### PR TITLE
fix(test): failing test for `/nosotros` route

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -20,8 +20,8 @@ describe('Pruebas del servidor HTTP', () => {
   });
 
   // Prueba para la ruta /nosotros
-  test('GET /nosotras debería devolver "Bienvenid@s a saber + de nosotros :)"', async () => {
-    const response = await request(server).get('/nosotras');
+  test('GET /nosotros debería devolver "Bienvenid@s a saber + de nosotros :)"', async () => {
+    const response = await request(server).get('/nosotros');
     expect(response.status).toBe(200);
     expect(response.text).toBe('Bienvenid@s a saber + de nosotros :)');
     expect(response.headers['content-type']).toMatch(/text\/plain/);


### PR DESCRIPTION
Corrige un error en la ruta usada en el test `/nosotros`.
El test hace petición a `/nosotras`, que no coincide con la ruta pedida en el readme `/nosotros`.

![image](https://github.com/user-attachments/assets/cf01c071-2056-403a-a75d-d69d97344542)
